### PR TITLE
Initialize SOAP interface from encounter templates

### DIFF
--- a/src/components/encounter/SmartEncounterWorkflow.tsx
+++ b/src/components/encounter/SmartEncounterWorkflow.tsx
@@ -383,13 +383,27 @@ export const SmartEncounterWorkflow: React.FC<EncounterWorkflowProps> = ({
                 name: selectedPatient.name,
                 age: selectedPatient.age,
                 gender: selectedPatient.gender,
-                chiefComplaint: appointment?.reason || 'Follow-up visit',
+                chiefComplaint: selectedTemplate?.default_reason || appointment?.reason || 'Follow-up visit',
                 vitals: {},
                 allergies: selectedPatient.allergies || [],
                 medications: selectedPatient.medications || [],
                 medicalHistory: selectedPatient.conditions || [],
                 conditions: selectedPatient.conditions || []
               }}
+              initialReason={selectedTemplate?.default_reason}
+              initialNotes={selectedTemplate?.default_notes}
+              initialDiagnoses={selectedTemplate?.default_diagnosis_codes
+                ? selectedTemplate.default_diagnosis_codes
+                    .split(',')
+                    .filter(Boolean)
+                    .map(code => ({ code: code.trim(), name: code.trim() }))
+                : undefined}
+              initialProcedures={selectedTemplate?.default_procedure_codes
+                ? selectedTemplate.default_procedure_codes
+                    .split(',')
+                    .filter(Boolean)
+                    .map(code => ({ code: code.trim(), name: code.trim() }))
+                : undefined}
               onSave={handleSoapSave}
               onComplete={handleEncounterComplete}
             />

--- a/src/components/encounter/StreamlinedSoapInterface.tsx
+++ b/src/components/encounter/StreamlinedSoapInterface.tsx
@@ -54,6 +54,10 @@ interface StreamlinedSoapInterfaceProps {
   patientContext?: PatientContext;
   onSave?: (data: SOAPData) => void;
   onComplete?: (data: SOAPData) => void;
+  initialReason?: string;
+  initialNotes?: string;
+  initialDiagnoses?: any[];
+  initialProcedures?: any[];
 }
 
 interface EncounterData {
@@ -163,33 +167,37 @@ export const StreamlinedSoapInterface: React.FC<StreamlinedSoapInterfaceProps> =
   appointment,
   patientContext,
   onSave,
-  onComplete
+  onComplete,
+  initialReason,
+  initialNotes,
+  initialDiagnoses,
+  initialProcedures
 }) => {
   const [currentStep, setCurrentStep] = useState(0);
   const [soapData, setSoapData] = useState<SOAPData>({
-    subjective: '',
+    subjective: initialReason || '',
     objective: '',
     assessment: '',
-    plan: ''
+    plan: initialNotes || ''
   });
   const [isVoiceRecording, setIsVoiceRecording] = useState(false);
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(true);
-  const [selectedDiagnoses, setSelectedDiagnoses] = useState<any[]>([]);
+  const [selectedDiagnoses, setSelectedDiagnoses] = useState<any[]>(initialDiagnoses || []);
   const [symptoms, setSymptoms] = useState<string[]>([]);
   const [physicalFindings, setPhysicalFindings] = useState<any[]>([]);
   const [vitalSigns, setVitalSigns] = useState<any>({});
   const [useAdvancedMode, setUseAdvancedMode] = useState(false);
-  const [selectedProcedures, setSelectedProcedures] = useState<any[]>([]);
+  const [selectedProcedures, setSelectedProcedures] = useState<any[]>(initialProcedures || []);
   const [encounterData, setEncounterData] = useState<EncounterData>({
     patientId: patientContext?.name || '',
     providerId: 'dr-001',
     appointmentId: appointment?.id,
-    subjective: '',
+    subjective: initialReason || '',
     objective: '',
     assessment: '',
-    plan: '',
-    diagnoses: [],
-    procedures: [],
+    plan: initialNotes || '',
+    diagnoses: initialDiagnoses || [],
+    procedures: initialProcedures || [],
     status: 'draft'
   });
 


### PR DESCRIPTION
## Summary
- Allow SOAP interface to accept initial reason, notes, diagnoses, and procedures
- Populate StreamlinedSoapInterface with defaults when a template is selected in SmartEncounterWorkflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 539 errors, 128 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e07ca524c8325bd2a54c94e0b8a0c