### PR TITLE
Reset encounter state when workflow dialog closes

### DIFF
--- a/src/components/encounter/SmartEncounterWorkflow.tsx
+++ b/src/components/encounter/SmartEncounterWorkflow.tsx
@@ -125,6 +125,20 @@ export const SmartEncounterWorkflow: React.FC<EncounterWorkflowProps> = ({
     return () => clearInterval(interval);
   }, [isTimerRunning, sessionStartTime]);
 
+  // Reset state when dialog closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedPatient(null);
+      setSelectedTemplate(null);
+      setEncounterType('');
+      setSessionStartTime(null);
+      setElapsedTime(0);
+      setIsTimerRunning(false);
+      setSoapData(null);
+      setCurrentStage('setup');
+    }
+  }, [isOpen]);
+
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;


### PR DESCRIPTION
## Summary
- reset SmartEncounterWorkflow state when dialog closes to avoid stale selections and timers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any errors and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e07d09a4c8325bf0c6943a2e7cb88