### PR TITLE
refactor: centralize encounter template type

### DIFF
--- a/src/components/encounter/SmartEncounterWorkflow.tsx
+++ b/src/components/encounter/SmartEncounterWorkflow.tsx
@@ -25,6 +25,7 @@ import { useSelector } from "react-redux";
 import type { RootState } from "@/redux/store";
 import { getTemplateApi } from "@/services/operations/encounter";
 import StreamlinedSoapInterface from './StreamlinedSoapInterface';
+import type { Template } from "@/types/encounter";
 
 interface Patient {
   id: string;
@@ -35,16 +36,6 @@ interface Patient {
   conditions?: string[];
   allergies?: string[];
   medications?: string[];
-}
-
-interface Template {
-  template_id: number;
-  template_name: string;
-  encounter_type: string;
-  default_reason: string;
-  default_notes: string;
-  default_diagnosis_codes: string;
-  default_procedure_codes: string;
 }
 
 interface EncounterWorkflowProps {

--- a/src/pages/CreateTemplate.tsx
+++ b/src/pages/CreateTemplate.tsx
@@ -16,17 +16,7 @@ import {
 import { toast } from "react-toastify";
 import { useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
-
-interface Template {
-  template_id?: number; // Optional as it's not present during creation
-  template_name: string;
-  encounter_type: string;
-  default_reason: string;
-  default_notes: string;
-  default_diagnosis_codes: string;
-  default_procedure_codes: string;
-  // 'created' field is deliberately excluded from this interface for frontend form data
-}
+import type { Template } from "@/types/encounter";
 
 const CreateTemplate = () => {
   const { token } = useSelector((state: RootState) => state.auth);

--- a/src/pages/EditEncounter.tsx
+++ b/src/pages/EditEncounter.tsx
@@ -27,17 +27,7 @@ import { toast } from "react-toastify";
 import { useSelector } from "react-redux";
 import type { RootState } from "@/redux/store";
 import { getAllPatientsAPI } from "@/services/operations/patient";
-
-// Interface for Template data from API
-interface Template {
-  template_id: number;
-  template_name: string;
-  encounter_type: string;
-  default_reason: string;
-  default_notes: string;
-  default_diagnosis_codes: string;
-  default_procedure_codes: string;
-}
+import type { Template } from "@/types/encounter";
 
 // Interface for Patient data from API
 interface Patient {

--- a/src/types/encounter.ts
+++ b/src/types/encounter.ts
@@ -1,0 +1,9 @@
+export interface Template {
+  template_id: number;
+  template_name: string;
+  encounter_type: string;
+  default_reason: string;
+  default_notes: string;
+  default_diagnosis_codes: string;
+  default_procedure_codes: string;
+}


### PR DESCRIPTION
## Summary
- add shared `Template` interface for encounter templates
- use `Template` type across template creation, editing, and smart workflow modules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 665 problems (537 errors, 128 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689e07d2549883258a18520c8b59318c